### PR TITLE
Handle no App_Data

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Startup.cs
+++ b/src/AppleFitnessWorkoutMapper/Startup.cs
@@ -53,6 +53,12 @@ namespace MartinCostello.AppleFitnessWorkoutMapper
                         }
 
                         options.DatabaseFile = Path.Combine(options.DataDirectory, options.DatabaseFileName);
+
+                        // Ensure the configured data directory exists
+                        if (!Directory.Exists(options.DataDirectory))
+                        {
+                            Directory.CreateDirectory(options.DataDirectory);
+                        }
                     });
 
             services.AddDbContext<TracksContext>((serviceProvider, builder) =>

--- a/src/AppleFitnessWorkoutMapper/appsettings.json
+++ b/src/AppleFitnessWorkoutMapper/appsettings.json
@@ -3,6 +3,7 @@
     "LogLevel": {
       "Default": "Information",
       "Microsoft": "Warning",
+      "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error",
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },


### PR DESCRIPTION
  * Create the configured data directory when the app starts if it doesn't already.
  * Suppress warning that's not a problem about the XML configuration system.

