### PR TITLE
Notarization for macOS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ indent_size = 2
 [*.{cs,csx,vb,vbx}]
 charset = utf-8-bom
 
+[*.plist]
+indent_style = tab
+
 [*.sln]
 charset = unset
 end_of_line = unset

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: app-macos
-        path: ${{ env.MACOS_ARTIFACTS_PATH }}
+        path: ${{ env.MACOS_ARTIFACTS_PATH }}/publish
 
     - name: Generate macOS app
       shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ env:
   DOTNET_MULTILEVEL_LOOKUP: 0
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
+  MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
+  MACOS_ARTIFACTS_PATH: ./artifacts
   NUGET_XMLDOC_MODE: skip
 
 jobs:
@@ -62,10 +65,102 @@ jobs:
         name: app-zips
         path: ./artifacts/publish/*.zip
 
+    - name: Publish artifacts
+      uses: actions/upload-artifact@v2
+      if: ${{ runner.os == 'Linux' }}
+      with:
+        name: app-macos
+        path: ./artifacts/publish/osx-x64
+
+  notarize:
+    #if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    name: notarize
+    needs: build
+    runs-on: macos-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: app-macos
+        path: ${{ env.MACOS_ARTIFACTS_PATH }}
+
+    - name: Generate macOS app
+      shell: pwsh
+      run: |
+        $Artifacts = "${{ env.MACOS_ARTIFACTS_PATH }}"
+        $AppName = "${{ env.MACOS_APP_NAME }}"
+        $AppPath = "${{ env.MACOS_APP_PATH }}"
+        $ContentsPath = (Join-Path ${AppPath} "Contents")
+        $PublishPath = (Join-Path ${Artifacts} "publish")
+        New-Item -Path ${Artifacts} -Name ${AppName} -ItemType "Directory" | Out-Null
+        New-Item -Path ${AppPath} -Name "Contents" -ItemType "Directory" | Out-Null
+        New-Item -Path ${ContentsPath} -Name "Resources" -ItemType "Directory" | Out-Null
+        Copy-Item -Path ${PublishPath} -Destination (Join-Path ${ContentsPath} "MacOS") -Recurse | Out-Null
+        Copy-Item -Path ./src/AppleFitnessWorkoutMapper/Info.plist -Destination ${ContentsPath} | Out-Null
+    - name: Configure Xcode
+      uses: devbotsxyz/xcode-select@v1
+      with:
+        version: "12.4"
+
+    - name: Import Distribution Certificate
+      uses: devbotsxyz/import-signing-certificate@v1
+      with:
+        certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
+        certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
+        keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+    - name: Sign app
+      shell: bash
+      env:
+        APP_NAME: ${{ env.MACOS_APP_PATH }}
+        ENTITLEMENTS: ./src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.entitlements
+        SIGNING_IDENTITY: ${{ secrets.SIGNING_IDENTITY }}
+      run: |
+        chmod +x $APP_NAME/Contents/MacOS/AppleFitnessWorkoutMapper
+        find "$APP_NAME/Contents/MacOS/"|while read fname; do
+            if [[ -f $fname ]]; then
+                echo "Signing $fname"
+                codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$fname" || true
+            fi
+        done
+        echo "Signing app file"
+        codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"
+    - name: Notarize app
+      uses: devbotsxyz/xcode-notarize@v1
+      with:
+        product-path: ${{ env.MACOS_APP_PATH }}
+        appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+        appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+
+    - name: Staple app
+      uses: devbotsxyz/xcode-staple@v1
+      with:
+        product-path: ${{ env.MACOS_APP_PATH }}
+
+    - name: Package signed app
+      run: ditto -V -c -k --keepParent ${{ env.MACOS_APP_PATH }} ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+
+    - name: Publish signed app
+      uses: actions/upload-artifact@v2
+      with:
+        name: app-macos-signed
+        path: ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+
+    - name: Publish signed app
+      uses: actions/upload-artifact@v2
+      with:
+        name: app-zips
+        path: ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+
   release:
     if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: release
-    needs: build
+    needs: notarize
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        #os: [ macos-latest, ubuntu-latest, windows-latest ]
+        os: [ ubuntu-latest ]
         include:
-          - os: macos-latest
-            codecov_os: macos
+          #- os: macos-latest
+          #  codecov_os: macos
           - os: ubuntu-latest
             codecov_os: linux
-          - os: windows-latest
-            codecov_os: windows
+          #- os: windows-latest
+          #  codecov_os: windows
 
     steps:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,15 +31,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        #os: [ macos-latest, ubuntu-latest, windows-latest ]
-        os: [ ubuntu-latest ]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
         include:
-          #- os: macos-latest
-          #  codecov_os: macos
+          - os: macos-latest
+            codecov_os: macos
           - os: ubuntu-latest
             codecov_os: linux
-          #- os: windows-latest
-          #  codecov_os: windows
+          - os: windows-latest
+            codecov_os: windows
 
     steps:
 
@@ -74,7 +73,7 @@ jobs:
         path: ./artifacts/publish/osx-x64
 
   notarize:
-    #if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: notarize
     needs: build
     runs-on: macos-latest
@@ -159,7 +158,6 @@ jobs:
         path: ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
 
   release:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: release
     needs: notarize
     runs-on: windows-latest

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,4 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(CI)' != '' or !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\node_modules') ">
-    <InstallWebPackages>true</InstallWebPackages>
-  </PropertyGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -129,6 +129,7 @@ ForEach ($project in $publishProjects) {
 
     $runtimes = @(
         "linux-x64",
+        "osx-x64",
         "win-x64"
     )
 

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -16,7 +16,7 @@
     <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="BeforeBuild">
-    <Exec Command="npm install" Condition=" '$(InstallWebPackages)' == 'true' " />
+    <Exec Command="npm install" Condition=" !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\node_modules') " />
     <Exec Command="npm run build" Condition=" ('$(BuildingInsideVisualStudio)' != 'true' and '$(GITHUB_ACTIONS)' != 'true') or !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\wwwroot\static\js\main.js') " />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="BeforeBuild">
     <Exec Command="npm install" Condition=" '$(InstallWebPackages)' == 'true' " />
-    <Exec Command="npm run build" Condition=" '$(BuildingInsideVisualStudio)' != 'true' or !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\wwwroot\static\js\main.js') " />
+    <Exec Command="npm run build" Condition=" ('$(BuildingInsideVisualStudio)' != 'true' and '$(GITHUB_ACTIONS)' != 'true') or !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\wwwroot\static\js\main.js') " />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.entitlements
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>com.apple.security.cs.allow-jit</key>
+		<true/>
+		<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+		<true/>
+		<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+		<true/>
+		<key>com.apple.security.cs.disable-library-validation</key>
+		<true/>
+	</dict>
+</plist>

--- a/src/AppleFitnessWorkoutMapper/Info.plist
+++ b/src/AppleFitnessWorkoutMapper/Info.plist
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleName</key>
+		<string>AppleFitnessWorkoutMapper</string>
+		<key>CFBundleDisplayName</key>
+		<string>Apple Fitness Workout Mapper</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.martincostello.applefitnessworkoutmapper</string>
+		<key>CFBundleVersion</key>
+		<string>1.0.0</string>
+		<key>CFBundlePackageType</key>
+		<string>APPL</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleExecutable</key>
+		<string>AppleFitnessWorkoutMapper</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0.0</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>10.13</string>
+		<key>NSPrincipalClass</key>
+		<string>NSApplication</string>
+		<key>NSHighResolutionCapable</key>
+		<true />
+		<key>CFBundleDevelopmentRegion</key>
+		<string>en-GB</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+	</dict>
+</plist>

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
@@ -164,7 +164,7 @@
                 }
                 <div class="alert alert-primary d-none" role="alert" id="total-distance-container">
                     You have travelled <span js-data-total-distance></span> <i class="bi bi-stars text-warning" aria-hidden="true"></i> &mdash;
-                    that&#39;s a saving of <span js-data-emissions></span>kgs of CO<sub>2</sub> compared to driving. <i class="bi bi-tree-fill text-success"></i>
+                    that&#39;s a saving of <span js-data-emissions></span>kg of CO<sub>2</sub> compared to driving. <i class="bi bi-tree-fill text-success"></i>
                 </div>
                 <div id="map"></div>
                 <footer class="mt-2 text-muted">


### PR DESCRIPTION
Add a new notarize job that takes the macOS version, and attempts to notarize it on a macOS image with Xcode based on [dotnet-macos-notarization-example](https://github.com/martincostello/dotnet-macos-notarization-example).

Once notarized, the signed version replaces the original ZIP file for macOS that was uploaded by the build job.
