### PR TITLE
Handle port in use errors nicer

### DIFF
--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -16,8 +16,8 @@
     <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>
   <Target Name="BundleAssets" BeforeTargets="BeforeBuild">
-    <Exec Command="npm install" Condition=" !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\node_modules') " />
-    <Exec Command="npm run build" Condition=" ('$(BuildingInsideVisualStudio)' != 'true' and '$(GITHUB_ACTIONS)' != 'true') or !Exists('$(MSBuildThisFileDirectory)\src\AppleFitnessWorkoutMapper\wwwroot\static\js\main.js') " />
+    <Exec Command="npm install" Condition=" !Exists('$(MSBuildThisFileDirectory)\node_modules') " />
+    <Exec Command="npm run build" Condition=" ('$(BuildingInsideVisualStudio)' != 'true' and '$(GITHUB_ACTIONS)' != 'true') or !Exists('$(MSBuildThisFileDirectory)\wwwroot\static\js\main.js') " />
   </Target>
   <Target Name="AddGeneratedContentItems" BeforeTargets="AssignTargetPaths">
     <ItemGroup>

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
@@ -8,8 +9,30 @@ namespace MartinCostello.AppleFitnessWorkoutMapper
 {
     public static class Program
     {
-        public static void Main(string[] args) =>
-            CreateHostBuilder(args).Build().Run();
+        public static int Main(string[] args)
+        {
+            try
+            {
+                CreateHostBuilder(args).Build().Run();
+                return 0;
+            }
+            catch (Exception ex) when (ex.InnerException is Microsoft.AspNetCore.Connections.AddressInUseException)
+            {
+                var oldColor = Console.ForegroundColor;
+                Console.ForegroundColor = ConsoleColor.DarkRed;
+
+                Console.Error.WriteLine();
+                Console.Error.WriteLine(ex.Message);
+                Console.Error.WriteLine(ex.InnerException.Message);
+                Console.Error.WriteLine();
+                Console.Error.WriteLine("Close any other copies of AppleFitnessWorkoutMapper that might be running and try again.");
+                Console.Error.WriteLine();
+
+                Console.ForegroundColor = oldColor;
+
+                return -1;
+            }
+        }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)


### PR DESCRIPTION
* Handle errors due to the HTTP(S) port already being in use with a more obvious error message to the user.
* Fix paths that aren't correct since the original code was moved from the root to the project file.
