### PR TITLE
Revert to macOS app

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,9 @@ env:
   DOTNET_MULTILEVEL_LOOKUP: 0
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-  MACOS_APP_PATH: ./artifacts/publish
+  MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
+  MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
+  MACOS_ARTIFACTS_PATH: ./artifacts
   NUGET_XMLDOC_MODE: skip
 
 jobs:
@@ -71,7 +73,7 @@ jobs:
         path: ./artifacts/publish/osx-x64
 
   notarize:
-    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+    #if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: notarize
     needs: build
     runs-on: macos-latest
@@ -85,7 +87,21 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: app-macos
-        path: ${{ env.MACOS_APP_PATH }}
+        path: ${{ env.MACOS_ARTIFACTS_PATH }}/publish
+
+    - name: Generate macOS app
+      shell: pwsh
+      run: |
+        $Artifacts = "${{ env.MACOS_ARTIFACTS_PATH }}"
+        $AppName = "${{ env.MACOS_APP_NAME }}"
+        $AppPath = "${{ env.MACOS_APP_PATH }}"
+        $ContentsPath = (Join-Path ${AppPath} "Contents")
+        $PublishPath = (Join-Path ${Artifacts} "publish")
+        New-Item -Path ${Artifacts} -Name ${AppName} -ItemType "Directory" | Out-Null
+        New-Item -Path ${AppPath} -Name "Contents" -ItemType "Directory" | Out-Null
+        New-Item -Path ${ContentsPath} -Name "Resources" -ItemType "Directory" | Out-Null
+        Copy-Item -Path ${PublishPath} -Destination (Join-Path ${ContentsPath} "MacOS") -Recurse | Out-Null
+        Copy-Item -Path ./src/AppleFitnessWorkoutMapper/Info.plist -Destination ${ContentsPath} | Out-Null
 
     - name: Configure Xcode
       uses: devbotsxyz/xcode-select@v1
@@ -106,13 +122,15 @@ jobs:
         ENTITLEMENTS: ./src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.entitlements
         SIGNING_IDENTITY: ${{ secrets.SIGNING_IDENTITY }}
       run: |
-        chmod +x $APP_PATH/AppleFitnessWorkoutMapper
-        find "$APP_PATH/"|while read fname; do
+        chmod +x $APP_PATH/Contents/MacOS/AppleFitnessWorkoutMapper
+        find "$APP_PATH/Contents/MacOS/"|while read fname; do
             if [[ -f $fname ]]; then
                 echo "Signing $fname"
                 codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$fname" || true
             fi
         done
+        echo "Signing app file"
+        codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_PATH"
 
     - name: Notarize app
       uses: devbotsxyz/xcode-notarize@v1
@@ -122,8 +140,13 @@ jobs:
         appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
         appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
 
+    - name: Staple app
+      uses: devbotsxyz/xcode-staple@v1
+      with:
+        product-path: ${{ env.MACOS_APP_PATH }}
+
     - name: Package signed app
-      run: ditto -V -c -k ${{ env.MACOS_APP_PATH }} ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+      run: ditto -V -c -k --keepParent ${{ env.MACOS_APP_PATH }} ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
 
     - name: Publish signed app
       uses: actions/upload-artifact@v2
@@ -138,6 +161,7 @@ jobs:
         path: ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
 
   release:
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     name: release
     needs: notarize
     runs-on: windows-latest

--- a/src/AppleFitnessWorkoutMapper/Info.plist
+++ b/src/AppleFitnessWorkoutMapper/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+	<dict>
+		<key>CFBundleName</key>
+		<string>AppleFitnessWorkoutMapper</string>
+		<key>CFBundleDisplayName</key>
+		<string>Apple Fitness Workout Mapper</string>
+		<key>CFBundleIdentifier</key>
+		<string>com.martincostello.applefitnessworkoutmapper</string>
+		<key>CFBundleVersion</key>
+		<string>1.0.0</string>
+		<key>CFBundlePackageType</key>
+		<string>APPL</string>
+		<key>CFBundleSignature</key>
+		<string>????</string>
+		<key>CFBundleExecutable</key>
+		<string>AppleFitnessWorkoutMapper</string>
+		<key>CFBundleShortVersionString</key>
+		<string>1.0.0</string>
+		<key>LSMinimumSystemVersion</key>
+		<string>10.13</string>
+		<key>NSPrincipalClass</key>
+		<string>NSApplication</string>
+		<key>NSHighResolutionCapable</key>
+		<true />
+		<key>CFBundleDevelopmentRegion</key>
+		<string>en-GB</string>
+		<key>CFBundleInfoDictionaryVersion</key>
+		<string>6.0</string>
+	</dict>
+</plist>


### PR DESCRIPTION
Skipping stapling causes too many issues, so go back to the .app approach.

Also updates to the installation instructions.
