### PR TITLE
Update Microsoft.Playwright

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.6" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.11.1-alpha-2" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.12.0-alpha-5" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="4.3.2" />
     <PackageVersion Include="Moq" Version="4.16.1" />

--- a/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
@@ -65,7 +65,6 @@ namespace MartinCostello.AppleFitnessWorkoutMapper
             if (IsRunningInGitHubActions)
             {
                 options.RecordVideoDir = "videos";
-                options.RecordVideoSize = new RecordVideoSize() { Width = 800, Height = 600 };
             }
 
             return options;
@@ -102,7 +101,7 @@ namespace MartinCostello.AppleFitnessWorkoutMapper
                 OperatingSystem.IsWindows() ? "windows" :
                 "other";
 
-            browserType = browserType.Replace(":", string.Empty, StringComparison.Ordinal);
+            browserType = browserType.Replace(':', '_');
 
             string utcNow = DateTimeOffset.UtcNow.ToString("yyyy-MM-dd-HH-mm-ss", CultureInfo.InvariantCulture);
             return $"{testName}_{browserType}_{os}_{utcNow}{extension}";


### PR DESCRIPTION
* Update to the latest release of Microsoft.Playwright and remove workaround for bug that's been fixed.
* Improve video names for browser channel tests.
