### PR TITLE
Enable colour output from .NET CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,12 @@ env:
   DOTNET_MULTILEVEL_LOOKUP: 0
   DOTNET_NOLOGO: true
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
   MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
   MACOS_ARTIFACTS_PATH: ./artifacts
   NUGET_XMLDOC_MODE: skip
+  TERM: xterm
 
 jobs:
   build:


### PR DESCRIPTION
Enable coloured output to the terminal in GitHub Actions for Linux and macOS.
