### PR TITLE
Minor fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,6 +145,7 @@ jobs:
       with:
         certificate-data: ${{ secrets.DISTRIBUTION_CERTIFICATE_DATA }}
         certificate-passphrase: ${{ secrets.DISTRIBUTION_CERTIFICATE_PASSPHRASE }}
+        keychain-name: ''
         keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
 
     - name: Sign app
@@ -196,7 +197,7 @@ jobs:
     name: release
     needs: notarize
     runs-on: windows-latest
-    
+
     permissions:
       contents: write
 

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -70,7 +70,7 @@ jobs:
         lighthouseCheckResults: ${{ steps.lighthouse.outputs.lighthouseCheckResults }}
         minAccessibilityScore: "95"
         minBestPracticesScore: "83"
-        minPerformanceScore: "50"
+        minPerformanceScore: "77"
         minProgressiveWebAppScore: "20"
         minSeoScore: "95"
 

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="NodaTime" />
   </ItemGroup>
   <ItemGroup>
-    <Content Update=".prettierrc.json;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
+    <Content Update=".prettierrc.json;coverage\**;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />
     <None Remove="scripts\ts\**\*.ts" />
     <TypeScriptCompile Include="scripts\ts\**\*.ts" />
   </ItemGroup>


### PR DESCRIPTION
- The parameter is declared as required so the GitHub Actions VSCode plugin complains.
- Do not include the JavaScript coverage in the publish output.
