### PR TITLE
Remove redundant suppressions

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.IO.Compression;
 using System.Text.Json.Serialization.Metadata;
 using MartinCostello.AppleFitnessWorkoutMapper;


### PR DESCRIPTION
Remove now-redundant suppressions for false-positive code analysis warnings.
