### PR TITLE
Update to ASP.NET Core 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,9 +138,11 @@ jobs:
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: runner.os == 'Linux'
       with:
-        name: app-macos
-        path: ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-x64
         if-no-files-found: error
+        name: app-macos
+        path: |
+          ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-arm64
+          ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-x64
 
     - name: Publish screenshots
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
@@ -167,7 +169,8 @@ jobs:
         if-no-files-found: ignore
 
   notarize:
-    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
+    if: github.event.repository.fork == false
+    #if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
     name: notarize
     needs: build
     runs-on: macos-latest
@@ -239,14 +242,18 @@ jobs:
       with:
         product-path: ${{ env.MACOS_APP_PATH }}
 
-    - name: Package signed app
-      run: ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+    - name: Package signed apps
+      run: |
+        ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
+        ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
 
-    - name: Publish signed app
+    - name: Publish signed apps
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: app-macos-signed
-        path: ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+        path: |
+          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
+          ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
 
     - name: GPG sign signed app
       env:
@@ -259,6 +266,8 @@ jobs:
           echo "${key}:6:" | gpg --import-ownertrust
         done
         echo "${GPG_PRIVATE_KEY}" | gpg --import --batch --yes --passphrase "${GPG_PASSPHRASE}"
+        gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip"
+        gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip"
         gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip"
         gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip"
 
@@ -267,13 +276,16 @@ jobs:
       with:
         name: app-zips
         path: |
+          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
+          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip.sig
           ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
           ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip.sig
 
   release:
+    if: false
     name: release
     needs: notarize
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     permissions:
       contents: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,12 +102,9 @@ jobs:
     - name: GPG sign ZIP artifacts
       if: |
         runner.os == 'Linux' &&
-        github.event.repository.fork == false
-      #if: |
-      #  runner.os == 'Linux' &&
-      #  github.event.repository.fork == false &&
-      #  (github.ref_name == github.event.repository.default_branch ||
-      #   startsWith(github.ref, 'refs/tags/v'))
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch ||
+         startsWith(github.ref, 'refs/tags/v'))
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -175,8 +172,7 @@ jobs:
         if-no-files-found: ignore
 
   notarize:
-    if: github.event.repository.fork == false
-    #if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
+    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
     needs: [ build ]
     runs-on: macos-latest
 
@@ -291,7 +287,6 @@ jobs:
           ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip.sig
 
   release:
-    if: false
     needs: [ notarize ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       shell: bash
       run: |
-        curl "https://api.github.com/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" | jq -r '.[].raw_key' | gpg --import
+        curl -s "https://api.github.com/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" | jq -r '.[].raw_key' | gpg --import
         gpg --list-keys --with-colons | awk -F: '/^fpr:/ { print $10 }' | while read -r key; do
           echo "${key}:6:" | gpg --import-ownertrust
         done
@@ -274,7 +274,7 @@ jobs:
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       shell: bash
       run: |
-        curl "https://api.github.com/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" | jq -r '.[].raw_key' | gpg --import
+        curl -s "https://api.github.com/users/${GITHUB_REPOSITORY_OWNER}/gpg_keys" | jq -r '.[].raw_key' | gpg --import
         gpg --list-keys --with-colons | awk -F: '/^fpr:/ { print $10 }' | while read -r key; do
           echo "${key}:6:" | gpg --import-ownertrust
         done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,15 +131,15 @@ jobs:
         if-no-files-found: error
         name: app-zips
         path: |
-          ./artifacts/publish/*.zip
-          ./artifacts/publish/*.zip.sig
+          ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip.sig
 
     - name: Publish macOS artifacts
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: runner.os == 'Linux'
       with:
         name: app-macos
-        path: ./artifacts/publish/osx-x64
+        path: ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-x64
         if-no-files-found: error
 
     - name: Publish screenshots

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,6 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_SYSTEM_CONSOLE_ALLOW_ANSI_COLOR_REDIRECTION: 1
   FORCE_COLOR: 1
-  MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
-  MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
-  MACOS_ARTIFACTS_PATH: ./artifacts
   NUGET_XMLDOC_MODE: skip
   TERM: xterm
 
@@ -105,9 +102,12 @@ jobs:
     - name: GPG sign ZIP artifacts
       if: |
         runner.os == 'Linux' &&
-        github.event.repository.fork == false &&
-        (github.ref_name == github.event.repository.default_branch ||
-         startsWith(github.ref, 'refs/tags/v'))
+        github.event.repository.fork == false
+      #if: |
+      #  runner.os == 'Linux' &&
+      #  github.event.repository.fork == false &&
+      #  (github.ref_name == github.event.repository.default_branch ||
+      #   startsWith(github.ref, 'refs/tags/v'))
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -134,15 +134,21 @@ jobs:
           ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
           ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip.sig
 
-    - name: Publish macOS artifacts
+    - name: Publish macOS arm64 artifacts
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: runner.os == 'Linux'
       with:
+        name: app-macos-arm64
+        path: ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-arm64
         if-no-files-found: error
-        name: app-macos
-        path: |
-          ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-arm64
-          ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-x64
+
+    - name: Publish macOS x64 artifacts
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+      if: runner.os == 'Linux'
+      with:
+        name: app-macos-x64
+        path: ./artifacts/publish/AppleFitnessWorkoutMapper/release_osx-x64
+        if-no-files-found: error
 
     - name: Publish screenshots
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
@@ -171,9 +177,19 @@ jobs:
   notarize:
     if: github.event.repository.fork == false
     #if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
-    name: notarize
-    needs: build
+    needs: [ build ]
     runs-on: macos-latest
+
+    env:
+      MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
+      MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
+      MACOS_ARTIFACTS_PATH: ./artifacts
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [ arm64, x64 ]
+      max-parallel: 1
 
     steps:
 
@@ -183,14 +199,14 @@ jobs:
     - name: Download artifacts
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
-        name: app-macos
+        name: app-macos-${{ matrix.platform }}
         path: ${{ env.MACOS_ARTIFACTS_PATH }}/publish
 
     - name: Generate macOS app
       shell: pwsh
       run: |
-        $Artifacts = "${{ env.MACOS_ARTIFACTS_PATH }}"
-        $AppPath = "${{ env.MACOS_APP_PATH }}"
+        $Artifacts = ${env:MACOS_ARTIFACTS_PATH}
+        $AppPath = ${env:MACOS_APP_PATH}
         $ContentsPath = (Join-Path ${AppPath} "Contents")
         $PublishPath = (Join-Path ${Artifacts} "publish")
         New-Item -Path ${Artifacts} -Name ${env:MACOS_APP_NAME} -ItemType "Directory" | Out-Null
@@ -242,21 +258,18 @@ jobs:
       with:
         product-path: ${{ env.MACOS_APP_PATH }}
 
-    - name: Package signed apps
-      run: |
-        ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
-        ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+    - name: Package signed app
+      run: ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
 
     - name: Publish signed apps
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: app-macos-signed
-        path: |
-          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
-          ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
+        path: ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
 
     - name: GPG sign signed app
       env:
+        APP_PLATFORM: ${{ matrix.platform }}
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
       shell: bash
@@ -266,25 +279,20 @@ jobs:
           echo "${key}:6:" | gpg --import-ownertrust
         done
         echo "${GPG_PRIVATE_KEY}" | gpg --import --batch --yes --passphrase "${GPG_PASSPHRASE}"
-        gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip"
-        gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip"
-        gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip"
-        gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip"
+        gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip"
+        gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip"
 
     - name: Update macOS ZIP artifacts
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: app-zips
         path: |
-          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip
-          ./artifacts/AppleFitnessWorkoutMapper-osx-arm64.zip.sig
-          ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip
-          ./artifacts/AppleFitnessWorkoutMapper-osx-x64.zip.sig
+          ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
+          ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip.sig
 
   release:
     if: false
-    name: release
-    needs: notarize
+    needs: [ notarize ]
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -261,7 +261,7 @@ jobs:
     - name: Package signed app
       run: ditto -V -c -k --keepParent "${MACOS_APP_PATH}" ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
 
-    - name: Publish signed apps
+    - name: Publish signed app
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: app-macos-signed

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -54,7 +54,7 @@ jobs:
         If ($StatusCode -ne 200) {
           throw "Failed to successfully connect to website after $Attempts attempts."
         }
-        New-Item -Path "${env:GITHUB_WORKSPACE}/artifacts" -ItemType Directory | Out-Null
+        New-Item -Path "${env:GITHUB_WORKSPACE}/artifacts/lighthouse" -ItemType Directory | Out-Null
 
     - name: Lighthouse
       uses: foo-software/lighthouse-check-action@f78f162ef0ecd48a18244c427959f0b79ef4d553 # v10.0.0
@@ -62,7 +62,7 @@ jobs:
       with:
         device: 'all'
         gitHubAccessToken: ${{ secrets.LIGHTHOUSE_ACCESS_TOKEN }}
-        outputDirectory: ${{ github.workspace }}/artifacts
+        outputDirectory: ${{ github.workspace }}/artifacts/lighthouse
         prCommentEnabled: true
         urls: 'https://localhost:5001'
         wait: true
@@ -82,4 +82,4 @@ jobs:
       if: ${{ always() }}
       with:
         name: lighthouse
-        path: ${{ github.workspace }}/artifacts
+        path: ${{ github.workspace }}/artifacts/lighthouse

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
           "type": "coreclr",
           "request": "launch",
           "preLaunchTask": "build",
-          "program": "${workspaceFolder}/src/AppleFitnessWorkoutMapper/bin/Debug/net7.0/AppleFitnessWorkoutMapper.dll",
+          "program": "${workspaceFolder}/src/AppleFitnessWorkoutMapper/bin/Debug/net8.0/AppleFitnessWorkoutMapper.dll",
           "args": [],
           "cwd": "${workspaceFolder}/src/AppleFitnessWorkoutMapper",
           "stopAtEntry": false,

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,8 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
+    <!-- HACK Disabled until RC2 due to https://github.com/dotnet/extensions/issues/4409 -->
+    <NoWarn>$(NoWarn);NU1603</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,7 +33,8 @@
     <RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
-    <VersionPrefix>1.2.1</VersionPrefix>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,8 +21,6 @@
     <LangVersion>latest</LangVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <!-- HACK Disabled until RC2 due to https://github.com/dotnet/extensions/issues/4409 -->
-    <NoWarn>$(NoWarn);NU1603</NoWarn>
     <NoWarn Condition=" '$(GenerateDocumentationFile)' != 'true' ">$(NoWarn);SA0001</NoWarn>
     <Nullable>enable</Nullable>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -24,7 +24,7 @@
     <ReportGeneratorOutputMarkdown Condition=" '$(ReportGeneratorOutputMarkdown)' == '' AND '$(GITHUB_SHA)' != '' ">true</ReportGeneratorOutputMarkdown>
     <ReportGeneratorReportTypes>HTML</ReportGeneratorReportTypes>
     <ReportGeneratorReportTypes Condition=" '$(ReportGeneratorOutputMarkdown)' == 'true' ">$(ReportGeneratorReportTypes);MarkdownSummaryGitHub</ReportGeneratorReportTypes>
-    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(OutputPath), 'coverage'))</ReportGeneratorTargetDirectory>
+    <ReportGeneratorTargetDirectory>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage'))</ReportGeneratorTargetDirectory>
     <_MarkdownSummaryPrefix>&lt;details&gt;&lt;summary&gt;:chart_with_upwards_trend: &lt;b&gt;$(AssemblyName) Code Coverage report&lt;/b&gt;&lt;/summary&gt;</_MarkdownSummaryPrefix>
     <_MarkdownSummarySuffix>&lt;/details&gt;</_MarkdownSummarySuffix>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-preview.7.23375.4" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.1.23419.6" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-preview.7.23407.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,8 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.1.23419.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23480.1" />
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.1.23453.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.23421.29" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.1.23419.6" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-preview.7.23407.5" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.1.23453.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,9 +3,9 @@
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23480.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23510.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.2.23480.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.2.23480.1" />
-    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.1.23453.1" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-rc.2.23510.2" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.2.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,19 +1,14 @@
 <Project>
-  <PropertyGroup>
-    <NodaTimeVersion>3.1.9</NodaTimeVersion>
-  </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.msbuild" Version="6.0.0" />
     <PackageVersion Include="GitHubActionsTestLogger" Version="2.3.3" />
     <PackageVersion Include="MartinCostello.Logging.XUnit" Version="0.3.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.13" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-preview.7.23375.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-preview.7.23375.4" />
+    <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="8.0.0-preview.7.23407.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.39.0" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.2.2" />
-    <PackageVersion Include="NodaTime" Version="$(NodaTimeVersion)" />
-    <PackageVersion Include="NodaTime.Testing" Version="$(NodaTimeVersion)" />
     <PackageVersion Include="ReportGenerator" Version="5.1.26" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.507" />
@@ -21,7 +16,6 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/build.ps1
+++ b/build.ps1
@@ -116,7 +116,9 @@ Write-Host "Publishing solution..." -ForegroundColor Green
 ForEach ($project in $publishProjects) {
 
     $runtimes = @(
+        "linux-arm64",
         "linux-x64",
+        "osx-arm64",
         "osx-x64",
         "win-x64"
     )

--- a/build.ps1
+++ b/build.ps1
@@ -79,7 +79,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --configuration "Release" $additionalArgs -- RunConfiguration.TestSessionTimeout=1200000
+    & $dotnet test $Project --configuration "Release" $additionalArgs --tl -- RunConfiguration.TestSessionTimeout=1200000
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
@@ -97,7 +97,7 @@ function DotNetPublish {
         $additionalArgs += $Runtime
     }
 
-    & $dotnet publish $Project $additionalArgs
+    & $dotnet publish $Project --tl $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"

--- a/build.ps1
+++ b/build.ps1
@@ -4,7 +4,6 @@
 #Requires -Version 7
 
 param(
-    [Parameter(Mandatory = $false)][string] $OutputPath = "",
     [Parameter(Mandatory = $false)][switch] $SkipTests
 )
 
@@ -15,10 +14,6 @@ $solutionPath = $PSScriptRoot
 $sdkFile = Join-Path $solutionPath "global.json"
 
 $dotnetVersion = (Get-Content $sdkFile | Out-String | ConvertFrom-Json).sdk.version
-
-if ($OutputPath -eq "") {
-    $OutputPath = Join-Path $PSScriptRoot "artifacts"
-}
 
 $installDotNetSdk = $false;
 
@@ -84,7 +79,7 @@ function DotNetTest {
         $additionalArgs += "GitHubActions;report-warnings=false"
     }
 
-    & $dotnet test $Project --configuration "Release" --output $OutputPath $additionalArgs -- RunConfiguration.TestSessionTimeout=1200000
+    & $dotnet test $Project --configuration "Release" $additionalArgs -- RunConfiguration.TestSessionTimeout=1200000
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet test failed with exit code $LASTEXITCODE"
@@ -102,7 +97,7 @@ function DotNetPublish {
         $additionalArgs += $Runtime
     }
 
-    & $dotnet publish $Project --output $PublishPath --configuration "Release" $additionalArgs
+    & $dotnet publish $Project $additionalArgs
 
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet publish failed with exit code $LASTEXITCODE"
@@ -126,12 +121,12 @@ ForEach ($project in $publishProjects) {
         "win-x64"
     )
 
-    $publishRootPath = (Join-Path $OutputPath "publish")
+    $publishRootPath = (Join-Path $PSScriptRoot "artifacts" "publish" "AppleFitnessWorkoutMapper")
 
     ForEach ($runtime in $runtimes) {
 
-        $publishPath = (Join-Path $publishRootPath $runtime)
-        DotNetPublish $project $runtime $publishPath
+        $publishPath = (Join-Path $publishRootPath "release_$runtime")
+        DotNetPublish $project $runtime
 
         if ($null -ne $env:GITHUB_ACTIONS) {
             $zipPath = (Join-Path $publishRootPath ("AppleFitnessWorkoutMapper-" + $runtime + ".zip"))
@@ -139,8 +134,8 @@ ForEach ($project in $publishProjects) {
         }
     }
 
-    $publishPath = (Join-Path $publishRootPath "portable")
-    DotNetPublish $project "" $publishPath
+    $publishPath = (Join-Path $publishRootPath "release")
+    DotNetPublish $project ""
 
     if ($null -ne $env:GITHUB_ACTIONS) {
         $zipPath = (Join-Path $publishRootPath ("AppleFitnessWorkoutMapper.zip"))

--- a/build.ps1
+++ b/build.ps1
@@ -120,6 +120,7 @@ ForEach ($project in $publishProjects) {
         "linux-x64",
         "osx-arm64",
         "osx-x64",
+        "win-arm64",
         "win-x64"
     )
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,7 +16,7 @@ system of the computer you wish to run Apple Fitness Workout Mapper on.
 
 For example, if you have an Apple Mac M2 computer download the
 `AppleFitnessWorkoutMapper-osx-arm64.zip` file, or if you have a Windows 10
-computer you would download the `AppleFitnessWorkoutMapper-win-x64.zip` file.
+Intel computer you would download the `AppleFitnessWorkoutMapper-win-x64.zip` file.
 
 If you do not see a specific download for your operating system, then download
 the portable version of the application, which is the ZIP file named

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,8 +14,8 @@ To install Apple Fitness Workout Mapper, navigate to the
 Find the latest stable release and download the ZIP file for the operating
 system of the computer you wish to run Apple Fitness Workout Mapper on.
 
-For example, if you have an Apple Mac computer download the
-`AppleFitnessWorkoutMapper-osx-x64.zip` file, or if you have a Windows 10
+For example, if you have an Apple Mac M2 computer download the
+`AppleFitnessWorkoutMapper-osx-arm64.zip` file, or if you have a Windows 10
 computer you would download the `AppleFitnessWorkoutMapper-win-x64.zip` file.
 
 If you do not see a specific download for your operating system, then download

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23463.5",
+    "version": "8.0.100-rc.2.23502.2",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.1.23455.8",
+    "version": "8.0.100-rc.1.23463.5",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-preview.7.23376.3",
+    "version": "8.0.100-rc.1.23455.8",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100-rc.2.23502.2",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.403",
+    "version": "8.0.100-preview.7.23376.3",
     "allowPrerelease": false,
     "rollForward": "latestMajor"
   }

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -1,8 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
+    <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <RootNamespace>MartinCostello.AppleFitnessWorkoutMapper</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <UserSecretsId>AppleFitnessWorkoutMapper</UserSecretsId>
@@ -10,7 +12,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
-    <PackageReference Include="NodaTime" />
   </ItemGroup>
   <ItemGroup>
     <Content Update="coverage\**\*;package.json;package-lock.json;tsconfig.json" CopyToPublishDirectory="Never" />

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -1,7 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
+    <!--
+      HACK Disable configuration binding source generator due to issues in RC.1 that will be fixed in RC.2:
+      - https://github.com/dotnet/runtime/issues/90851
+      - https://github.com/dotnet/runtime/issues/90987
+      - https://github.com/dotnet/runtime/issues/91258
+    -->
+    <!--
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
+    -->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <RootNamespace>MartinCostello.AppleFitnessWorkoutMapper</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -1,15 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
-    <!--
-      HACK Disable configuration binding source generator due to issues in RC.1 that will be fixed in RC.2:
-      - https://github.com/dotnet/runtime/issues/90851
-      - https://github.com/dotnet/runtime/issues/90987
-      - https://github.com/dotnet/runtime/issues/91258
-    -->
-    <!--
     <EnableConfigurationBindingGenerator>true</EnableConfigurationBindingGenerator>
-    -->
     <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
     <RootNamespace>MartinCostello.AppleFitnessWorkoutMapper</RootNamespace>
     <TargetFramework>net8.0</TargetFramework>

--- a/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
+++ b/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
@@ -5,13 +5,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Data;
 
-public sealed class TracksContext : DbContext
+public sealed class TracksContext(DbContextOptions options) : DbContext(options)
 {
-    public TracksContext(DbContextOptions options)
-        : base(options)
-    {
-    }
-
     public DbSet<Track> Tracks { get; set; } = null!;
 
     public DbSet<TrackPoint> TrackPoints { get; set; } = null!;

--- a/src/AppleFitnessWorkoutMapper/Info.plist
+++ b/src/AppleFitnessWorkoutMapper/Info.plist
@@ -23,7 +23,7 @@
 		<key>CFBundleVersion</key>
 		<string>1.3.0</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.13</string>
+		<string>10.15</string>
 		<key>NSHumanReadableCopyright</key>
 		<string>Martin Costello (c) 2021</string>
 	</dict>

--- a/src/AppleFitnessWorkoutMapper/Info.plist
+++ b/src/AppleFitnessWorkoutMapper/Info.plist
@@ -17,11 +17,11 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>1.2.1</string>
+		<string>1.3.0</string>
 		<key>CFBundleSignature</key>
 		<string>????</string>
 		<key>CFBundleVersion</key>
-		<string>1.2.1</string>
+		<string>1.3.0</string>
 		<key>LSMinimumSystemVersion</key>
 		<string>10.13</string>
 		<key>NSHumanReadableCopyright</key>

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
@@ -5,7 +5,7 @@
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 @model IndexModel
 @{
-    var today = Model.Clock.GetCurrentInstant().ToDateTimeUtc().Date;
+    var today = Model.TimeProvider.GetUtcNow().UtcDateTime.Date;
     string startDate = today.AddDays(-28).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
     string endDate = today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
 }

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
@@ -3,19 +3,18 @@
 
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
-using NodaTime;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Pages;
 
 public class IndexModel : PageModel
 {
-    public IndexModel(IClock clock, IOptions<ApplicationOptions> options)
+    public IndexModel(TimeProvider timeProvider, IOptions<ApplicationOptions> options)
     {
-        Clock = clock;
+        TimeProvider = timeProvider;
         GoogleMapsApiKey = options.Value.GoogleMapsApiKey;
     }
 
-    public IClock Clock { get; }
+    public TimeProvider TimeProvider { get; }
 
     public string GoogleMapsApiKey { get; }
 

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
@@ -6,17 +6,11 @@ using Microsoft.Extensions.Options;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Pages;
 
-public class IndexModel : PageModel
+public class IndexModel(TimeProvider timeProvider, IOptions<ApplicationOptions> options) : PageModel
 {
-    public IndexModel(TimeProvider timeProvider, IOptions<ApplicationOptions> options)
-    {
-        TimeProvider = timeProvider;
-        GoogleMapsApiKey = options.Value.GoogleMapsApiKey;
-    }
+    public TimeProvider TimeProvider { get; } = timeProvider;
 
-    public TimeProvider TimeProvider { get; }
-
-    public string GoogleMapsApiKey { get; }
+    public string GoogleMapsApiKey { get; } = options.Value.GoogleMapsApiKey;
 
     public void OnGet()
     {

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
-#pragma warning disable CA1852
-
 using System.IO.Compression;
 using MartinCostello.AppleFitnessWorkoutMapper;
 using MartinCostello.AppleFitnessWorkoutMapper.Data;

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -4,7 +4,6 @@
 #pragma warning disable CA1852
 
 using System.IO.Compression;
-using System.Text.Json.Serialization.Metadata;
 using MartinCostello.AppleFitnessWorkoutMapper;
 using MartinCostello.AppleFitnessWorkoutMapper.Data;
 using MartinCostello.AppleFitnessWorkoutMapper.Models;
@@ -13,7 +12,6 @@ using Microsoft.AspNetCore.ResponseCompression;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Options;
-using NodaTime;
 
 try
 {
@@ -69,12 +67,8 @@ static void RunApplication(string[] args)
             }
         });
 
-    builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>((options) =>
-    {
-        options.SerializerOptions.TypeInfoResolver = JsonTypeInfoResolver.Combine(
-            ApplicationJsonSerializerContext.Default,
-            new DefaultJsonTypeInfoResolver());
-    });
+    builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(
+        (options) => options.SerializerOptions.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default));
 
     builder.Services.Configure<StaticFileOptions>((options) =>
     {
@@ -108,7 +102,7 @@ static void RunApplication(string[] args)
         builder.UseSqlite("Data Source=" + options.Value.DatabaseFile);
     });
 
-    builder.Services.TryAddSingleton<IClock>((_) => SystemClock.Instance);
+    builder.Services.TryAddSingleton(TimeProvider.System);
     builder.Services.AddSingleton<TrackParser>();
     builder.Services.AddScoped<TrackImporter>();
     builder.Services.AddScoped<TrackService>();

--- a/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
+++ b/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
@@ -6,20 +6,13 @@ using Microsoft.EntityFrameworkCore;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Services;
 
-public class TrackService
+public class TrackService(TracksContext context)
 {
-    private readonly TracksContext _context;
-
-    public TrackService(TracksContext context)
-    {
-        _context = context;
-    }
-
     public async Task<int> GetTrackCountAsync(CancellationToken cancellationToken = default)
     {
         await EnsureDatabaseAsync(cancellationToken);
 
-        return await _context.Tracks.CountAsync(cancellationToken);
+        return await context.Tracks.CountAsync(cancellationToken);
     }
 
     public async Task<IList<Models.Track>> GetTracksAsync(
@@ -32,7 +25,7 @@ public class TrackService
         DateTime notBefore = (since ?? DateTimeOffset.MinValue).UtcDateTime;
         DateTime notAfter = (until ?? DateTimeOffset.MaxValue).UtcDateTime;
 
-        var tracks = await _context.Tracks
+        var tracks = await context.Tracks
             .Where((p) => p.Timestamp > notBefore)
             .Where((p) => p.Timestamp < notAfter)
             .OrderBy((p) => p.Timestamp)
@@ -48,7 +41,7 @@ public class TrackService
                 Timestamp = new DateTimeOffset(track.Timestamp, TimeSpan.Zero),
             };
 
-            var points = _context.TrackPoints
+            var points = context.TrackPoints
                 .Where((p) => p.TrackId == track.Id)
                 .OrderBy((p) => p.Timestamp)
                 .AsAsyncEnumerable()
@@ -74,6 +67,6 @@ public class TrackService
 
     private async Task EnsureDatabaseAsync(CancellationToken cancellationToken)
     {
-        await _context.Database.EnsureCreatedAsync(cancellationToken);
+        await context.Database.EnsureCreatedAsync(cancellationToken);
     }
 }

--- a/src/AppleFitnessWorkoutMapper/package-lock.json
+++ b/src/AppleFitnessWorkoutMapper/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "applefitnessworkoutmapper",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "applefitnessworkoutmapper",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.23.2",

--- a/src/AppleFitnessWorkoutMapper/package.json
+++ b/src/AppleFitnessWorkoutMapper/package.json
@@ -1,7 +1,7 @@
 {
   "name": "applefitnessworkoutmapper",
   "private": true,
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Visualise multiple journeys from Apple Fitness on a map",
   "scripts": {
     "build": "npm run compile && npm run format && npm run lint && npm test",

--- a/tests/AppleFitnessWorkoutMapper.Tests/AppTests.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/AppTests.cs
@@ -7,14 +7,9 @@ using MartinCostello.AppleFitnessWorkoutMapper.Models;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
-public class AppTests
+public class AppTests(ITestOutputHelper outputHelper)
 {
-    public AppTests(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-    }
-
-    public ITestOutputHelper OutputHelper { get; set; }
+    public ITestOutputHelper OutputHelper { get; set; } = outputHelper;
 
     [Fact]
     public async Task Can_Load_Homepage()

--- a/tests/AppleFitnessWorkoutMapper.Tests/AppleFitnessWorkoutMapper.Tests.csproj
+++ b/tests/AppleFitnessWorkoutMapper.Tests/AppleFitnessWorkoutMapper.Tests.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);CA1707;CA1861;CA2234</NoWarn>
+    <NoWarn>$(NoWarn);CA1707;CA1861;CA2234;EXTEXP0004</NoWarn>
     <RootNamespace>MartinCostello.AppleFitnessWorkoutMapper</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" PrivateAssets="All" />
     <PackageReference Include="GitHubActionsTestLogger" />
     <PackageReference Include="MartinCostello.Logging.XUnit" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.Playwright" />
-    <PackageReference Include="NodaTime.Testing" />
     <PackageReference Include="ReportGenerator" PrivateAssets="All" />
     <PackageReference Include="Shouldly" />
     <PackageReference Include="xunit" />
@@ -27,7 +27,7 @@
   </ItemGroup>
   <PropertyGroup>
     <CollectCoverage>true</CollectCoverage>
-    <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
+    <CoverletOutput>$([System.IO.Path]::Combine($(ArtifactsPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[xunit.*]*</Exclude>
     <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>

--- a/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
@@ -9,7 +9,7 @@ namespace MartinCostello.AppleFitnessWorkoutMapper;
 public class BrowserFixture
 {
     private const string VideosDirectory = "videos";
-    private const string AssetsDirectory = ".";
+    private static readonly string AssetsDirectory = Path.Combine("..", "..", "..");
 
     public BrowserFixture(
         BrowserFixtureOptions options,

--- a/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/BrowserFixture.cs
@@ -6,24 +6,16 @@ using Microsoft.Playwright;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
-public class BrowserFixture
+public class BrowserFixture(
+    BrowserFixtureOptions options,
+    ITestOutputHelper outputHelper)
 {
     private const string VideosDirectory = "videos";
     private static readonly string AssetsDirectory = Path.Combine("..", "..", "..");
 
-    public BrowserFixture(
-        BrowserFixtureOptions options,
-        ITestOutputHelper outputHelper)
-    {
-        Options = options;
-        OutputHelper = outputHelper;
-    }
-
     internal static bool IsRunningInGitHubActions { get; } = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
 
-    private BrowserFixtureOptions Options { get; }
-
-    private ITestOutputHelper OutputHelper { get; }
+    private BrowserFixtureOptions Options { get; } = options;
 
     public async Task WithPageAsync(
         Func<IPage, Task> action,
@@ -50,8 +42,8 @@ public class BrowserFixture
 
         var page = await context.NewPageAsync();
 
-        page.Console += (_, e) => OutputHelper.WriteLine(e.Text);
-        page.PageError += (_, e) => OutputHelper.WriteLine(e);
+        page.Console += (_, e) => outputHelper.WriteLine(e.Text);
+        page.PageError += (_, e) => outputHelper.WriteLine(e);
 
         try
         {
@@ -71,7 +63,7 @@ public class BrowserFixture
 
                 await context.Tracing.StopAsync(new() { Path = path });
 
-                OutputHelper.WriteLine($"Trace saved to {path}.");
+                outputHelper.WriteLine($"Trace saved to {path}.");
             }
 
             await TryCaptureVideoAsync(page, activeTestName);
@@ -144,11 +136,11 @@ public class BrowserFixture
 
             await page.ScreenshotAsync(new() { Path = path });
 
-            OutputHelper.WriteLine($"Screenshot saved to {path}.");
+            outputHelper.WriteLine($"Screenshot saved to {path}.");
         }
         catch (Exception ex)
         {
-            OutputHelper.WriteLine("Failed to capture screenshot: " + ex);
+            outputHelper.WriteLine("Failed to capture screenshot: " + ex);
         }
     }
 
@@ -167,11 +159,11 @@ public class BrowserFixture
             await page.CloseAsync();
             await page.Video.SaveAsAsync(path);
 
-            OutputHelper.WriteLine($"Video saved to {path}.");
+            outputHelper.WriteLine($"Video saved to {path}.");
         }
         catch (Exception ex)
         {
-            OutputHelper.WriteLine("Failed to capture video: " + ex);
+            outputHelper.WriteLine("Failed to capture video: " + ex);
         }
     }
 }

--- a/tests/AppleFitnessWorkoutMapper.Tests/HttpWebApplicationFactory.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/HttpWebApplicationFactory.cs
@@ -10,15 +10,10 @@ using Microsoft.Extensions.Hosting;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
-internal sealed class HttpWebApplicationFactory : WebApplicationFactory
+internal sealed class HttpWebApplicationFactory(ITestOutputHelper outputHelper) : WebApplicationFactory(outputHelper)
 {
     private IHost? _host;
     private bool _disposed;
-
-    public HttpWebApplicationFactory(ITestOutputHelper outputHelper)
-        : base(outputHelper)
-    {
-    }
 
     public string ServerAddress
     {

--- a/tests/AppleFitnessWorkoutMapper.Tests/Pages/ApplicationPage.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/Pages/ApplicationPage.cs
@@ -5,21 +5,14 @@ using Microsoft.Playwright;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Pages;
 
-public sealed class ApplicationPage
+public sealed class ApplicationPage(IPage page)
 {
     private const string FilterSelector = "id=filter";
 
-    private readonly IPage _page;
-
-    public ApplicationPage(IPage page)
-    {
-        _page = page;
-    }
-
     public async Task FilterAsync()
     {
-        await _page.ClickAsync(FilterSelector);
-        await _page.WaitUntilEnabledAsync(FilterSelector);
+        await page.ClickAsync(FilterSelector);
+        await page.WaitUntilEnabledAsync(FilterSelector);
 
         await WaitForLoaderToBeHiddenAsync();
     }
@@ -27,15 +20,15 @@ public sealed class ApplicationPage
     public async Task ImportDataAsync()
     {
         // Start the import
-        await _page.ClickAsync("id=import");
+        await page.ClickAsync("id=import");
 
         // Wait for the import to complete
-        await _page.WaitUntilEnabledAsync(FilterSelector);
+        await page.WaitUntilEnabledAsync(FilterSelector);
         await WaitForLoaderToBeHiddenAsync();
     }
 
     public async Task<bool> IsMapDisplayedAsync()
-        => await _page.IsVisibleAsync("[aria-label='Map']");
+        => await page.IsVisibleAsync("[aria-label='Map']");
 
     public async Task<ApplicationPage> NotBeforeAsync(string value)
     {
@@ -50,14 +43,14 @@ public sealed class ApplicationPage
     }
 
     public async Task<string> EmissionsAsync()
-        => await _page.InnerTextTrimmedAsync("[js-data-emissions]");
+        => await page.InnerTextTrimmedAsync("[js-data-emissions]");
 
     public async Task<string> TotalDistanceAsync()
-        => await _page.InnerTextTrimmedAsync("[js-data-total-distance]");
+        => await page.InnerTextTrimmedAsync("[js-data-total-distance]");
 
     public async Task<IReadOnlyList<TrackItem>> TracksAsync()
     {
-        IReadOnlyList<IElementHandle> children = await _page.QuerySelectorAllAsync("css=.track-item");
+        IReadOnlyList<IElementHandle> children = await page.QuerySelectorAllAsync("css=.track-item");
 
         return children
             .Skip(1)
@@ -67,20 +60,20 @@ public sealed class ApplicationPage
 
     public async Task HidePolygonAsync()
     {
-        await _page.ClickAsync("[for='show-polygon'][class~='toggle-on']");
+        await page.ClickAsync("[for='show-polygon'][class~='toggle-on']");
     }
 
     public async Task ShowPolygonAsync()
     {
-        await _page.ClickAsync("[for='show-polygon'][class~='toggle-off']");
+        await page.ClickAsync("[for='show-polygon'][class~='toggle-off']");
     }
 
     public async Task UseKilometersAsync()
     {
         string selector = "[for='unit-of-distance'][class~='toggle-on']";
 
-        await _page.ClickAsync(selector);
-        await _page.WaitUntilEnabledAsync(selector);
+        await page.ClickAsync(selector);
+        await page.WaitUntilEnabledAsync(selector);
 
         await WaitForLoaderToBeHiddenAsync();
     }
@@ -89,15 +82,15 @@ public sealed class ApplicationPage
     {
         string selector = "[for='unit-of-distance'][class~='toggle-off']";
 
-        await _page.ClickAsync(selector);
-        await _page.WaitUntilEnabledAsync(selector);
+        await page.ClickAsync(selector);
+        await page.WaitUntilEnabledAsync(selector);
 
         await WaitForLoaderToBeHiddenAsync();
     }
 
     public async Task<ApplicationPage> EnterDateAsync(string selector, string value)
     {
-        var locator = _page.Locator(selector);
+        var locator = page.Locator(selector);
 
         await locator.ClearAsync();
         await locator.PressSequentiallyAsync(value);
@@ -107,8 +100,8 @@ public sealed class ApplicationPage
     }
 
     public async Task WaitForTracksAsync()
-        => await _page.WaitUntilVisibleAsync("css=.track-item");
+        => await page.WaitUntilVisibleAsync("css=.track-item");
 
     private async Task WaitForLoaderToBeHiddenAsync()
-        => await _page.WaitUntilHiddenAsync("id=tracks-loader");
+        => await page.WaitUntilHiddenAsync("id=tracks-loader");
 }

--- a/tests/AppleFitnessWorkoutMapper.Tests/Pages/TrackItem.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/Pages/TrackItem.cs
@@ -5,34 +5,27 @@ using Microsoft.Playwright;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Pages;
 
-public sealed class TrackItem
+public sealed class TrackItem(IElementHandle element)
 {
-    private readonly IElementHandle _element;
-
-    public TrackItem(IElementHandle element)
-    {
-        _element = element;
-    }
-
     public async Task ExpandAsync()
     {
-        await _element.ClickAsync();
+        await element.ClickAsync();
 
-        IElementHandle? child = await _element.QuerySelectorAsync("[data-js-visible]");
+        IElementHandle? child = await element.QuerySelectorAsync("[data-js-visible]");
 
         child.ShouldNotBeNull();
         await child.WaitForElementStateAsync(ElementState.Visible);
     }
 
     public async Task CollapseAsync()
-        => await _element.ClickAsync();
+        => await element.ClickAsync();
 
     public async Task<string> LinkTextAsync()
         => await InnerTextTrimmedAsync("a");
 
     public async Task<string> NameAsync()
     {
-        IElementHandle? child = await _element.QuerySelectorAsync("[data-track-name]");
+        IElementHandle? child = await element.QuerySelectorAsync("[data-track-name]");
         child.ShouldNotBeNull();
         return await child.GetAttributeAsync("data-track-name") ?? string.Empty;
     }
@@ -54,7 +47,7 @@ public sealed class TrackItem
 
     private async Task<string> InnerTextTrimmedAsync(string selector)
     {
-        IElementHandle? child = await _element.QuerySelectorAsync(selector);
+        IElementHandle? child = await element.QuerySelectorAsync(selector);
 
         child.ShouldNotBeNull();
         string text = await child.InnerTextAsync();

--- a/tests/AppleFitnessWorkoutMapper.Tests/Services/TrackParserTests.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/Services/TrackParserTests.cs
@@ -5,15 +5,8 @@ using MartinCostello.AppleFitnessWorkoutMapper.Models;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Services;
 
-public class TrackParserTests
+public class TrackParserTests(ITestOutputHelper outputHelper)
 {
-    private readonly ITestOutputHelper _outputHelper;
-
-    public TrackParserTests(ITestOutputHelper outputHelper)
-    {
-        _outputHelper = outputHelper;
-    }
-
     [Fact]
     public async Task Can_Parse_Track_Points_From_Disk()
     {
@@ -87,7 +80,7 @@ public class TrackParserTests
         };
 
         var options = Microsoft.Extensions.Options.Options.Create(application);
-        var logger = _outputHelper.ToLogger<TrackParser>();
+        var logger = outputHelper.ToLogger<TrackParser>();
 
         return new TrackParser(options, logger);
     }

--- a/tests/AppleFitnessWorkoutMapper.Tests/TaskExtensions.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/TaskExtensions.cs
@@ -6,14 +6,10 @@ namespace MartinCostello.AppleFitnessWorkoutMapper;
 internal static class TaskExtensions
 {
     public static async Task<T> ThenAsync<T>(this Task<T> value, Func<T, Task<T>> continuation)
-    {
-        return await continuation(await value);
-    }
+        => await continuation(await value);
 
     public static async Task ThenAsync<T>(this Task<T> value, Func<T, Task> continuation)
-    {
-        await continuation(await value);
-    }
+        => await continuation(await value);
 
     public static async Task ShouldBe(this Task<string> task, string expected)
     {

--- a/tests/AppleFitnessWorkoutMapper.Tests/UITests.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/UITests.cs
@@ -6,14 +6,9 @@ using Microsoft.Playwright;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
-public class UITests : IAsyncLifetime
+public class UITests(ITestOutputHelper outputHelper) : IAsyncLifetime
 {
-    public UITests(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-    }
-
-    public ITestOutputHelper OutputHelper { get; set; }
+    public ITestOutputHelper OutputHelper { get; set; } = outputHelper;
 
     public static IEnumerable<object?[]> Browsers()
     {

--- a/tests/AppleFitnessWorkoutMapper.Tests/WebApplicationFactory.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/WebApplicationFactory.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using NodaTime;
+using Microsoft.Extensions.Time.Testing;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
@@ -34,11 +34,12 @@ internal class WebApplicationFactory : WebApplicationFactory<ApplicationOptions>
             KeyValuePair.Create<string, string?>("DataDirectory", AppDataDirectory),
         };
 
-        var utcNow = Instant.FromUtc(2021, 06, 01, 12, 34, 56);
+        var utcNow = new DateTimeOffset(2021, 06, 01, 12, 34, 56, TimeSpan.Zero);
+        var timeProvider = new FakeTimeProvider(utcNow);
 
         builder.ConfigureAppConfiguration((p) => p.AddInMemoryCollection(config))
                .ConfigureLogging((p) => p.AddXUnit(this))
-               .ConfigureServices((p) => p.AddSingleton<IClock>((_) => new NodaTime.Testing.FakeClock(utcNow)))
+               .ConfigureServices((p) => p.AddSingleton<TimeProvider>(timeProvider))
                .UseSolutionRelativeContentRoot(Path.Combine("src", "AppleFitnessWorkoutMapper"));
     }
 

--- a/tests/AppleFitnessWorkoutMapper.Tests/WebApplicationFactory.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/WebApplicationFactory.cs
@@ -12,17 +12,11 @@ using Microsoft.Extensions.Time.Testing;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper;
 
-internal class WebApplicationFactory : WebApplicationFactory<ApplicationOptions>, ITestOutputHelperAccessor
+internal class WebApplicationFactory(ITestOutputHelper outputHelper) : WebApplicationFactory<ApplicationOptions>, ITestOutputHelperAccessor
 {
-    public WebApplicationFactory(ITestOutputHelper outputHelper)
-    {
-        OutputHelper = outputHelper;
-        AppDataDirectory = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location)!, "App_Data");
-    }
+    public string AppDataDirectory { get; } = Path.Combine(Path.GetDirectoryName(typeof(WebApplicationFactory).Assembly.Location)!, "App_Data");
 
-    public string AppDataDirectory { get; }
-
-    public ITestOutputHelper? OutputHelper { get; set; }
+    public ITestOutputHelper? OutputHelper { get; set; } = outputHelper;
 
     private string DatabaseFileName { get; } = Guid.NewGuid().ToString() + ".db";
 


### PR DESCRIPTION
- Update to ASP.NET Core 8.
- Produce arm64 and x64 versions for Linux and macOS.
- Use artifacts output.
- Use `TimeProvider` instead of NodaTime.
- Use configuration binding and request delegate source generators.
- Remove redundant `--configuration` arguments.
- Remove SourceLink as it is now included in the .NET SDK.
- Fix new analyzer warnings.
