### PR TITLE
Exclude [GeneratedCode]

### DIFF
--- a/tests/AppleFitnessWorkoutMapper.Tests/AppleFitnessWorkoutMapper.Tests.csproj
+++ b/tests/AppleFitnessWorkoutMapper.Tests/AppleFitnessWorkoutMapper.Tests.csproj
@@ -31,7 +31,7 @@
     <CoverletOutput>$([System.IO.Path]::Combine($(OutputPath), 'coverage', 'coverage'))</CoverletOutput>
     <CoverletOutputFormat>cobertura,json</CoverletOutputFormat>
     <Exclude>[xunit.*]*</Exclude>
-    <ExcludeByAttribute>System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
-    <Threshold>70</Threshold>
+    <ExcludeByAttribute>GeneratedCodeAttribute</ExcludeByAttribute>
+    <Threshold>75</Threshold>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Exclude code decorated with `[GeneratedCode]` from code coverage.
