### PR TITLE
Tweaks

### DIFF
--- a/src/AppleFitnessWorkoutMapper/ApplicationJsonSerializerContext.cs
+++ b/src/AppleFitnessWorkoutMapper/ApplicationJsonSerializerContext.cs
@@ -10,6 +10,7 @@ namespace MartinCostello.AppleFitnessWorkoutMapper;
 [ExcludeFromCodeCoverage]
 [JsonSerializable(typeof(List<Track>))]
 [JsonSerializable(typeof(TrackCount))]
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase)]
 internal sealed partial class ApplicationJsonSerializerContext : JsonSerializerContext
 {
 }

--- a/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
+++ b/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
@@ -7,7 +7,7 @@ namespace MartinCostello.AppleFitnessWorkoutMapper.Data;
 
 public sealed class TracksContext(DbContextOptions options) : DbContext(options)
 {
-    public DbSet<Track> Tracks { get; set; } = null!;
+    public DbSet<Track> Tracks { get; init; }
 
-    public DbSet<TrackPoint> TrackPoints { get; set; } = null!;
+    public DbSet<TrackPoint> TrackPoints { get; init; }
 }

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
@@ -168,7 +168,7 @@
                     You have travelled <span js-data-total-distance></span> <i class="bi bi-stars text-warning" aria-hidden="true"></i> &mdash;
                     that&#39;s a saving of <span js-data-emissions></span>kg of CO<sub>2</sub> compared to driving. <i class="bi bi-tree-fill text-success"></i>
                 </div>
-                <div id="map"></div>
+                <div id="map" data-google-api-key="@(Model.GoogleMapsApiKey)"></div>
                 <footer class="mt-2 text-muted">
                     Designed with <i class="bi bi-heart-fill" aria-label="love" role="img"></i> by <a href="https://martincostello.com/home/about/" rel="nofollow" target="_blank">Martin Costello</a>, &copy; @DateTimeOffset.UtcNow.Year |
                     <i class="bi bi-github" aria-hidden="true"></i> <a href="https://github.com/martincostello" rel="nofollow" target="_blank">GitHub</a> |
@@ -181,7 +181,6 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/4.6.1/js/bootstrap.min.js" integrity="sha512-UR25UO94eTnCVwjbXozyeVd6ZqpaAE9naiEUBK/A+QDbfSTQFhPGj5lOR6d8tsgbBk84Ggb5A3EkjsOgPRPcKA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap4-toggle/3.6.1/bootstrap4-toggle.min.js" integrity="sha512-bAjB1exAvX02w2izu+Oy4J96kEr1WOkG6nRRlCtOSQ0XujDtmAstq5ytbeIxZKuT9G+KzBmNq5d23D6bkGo8Kg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.9.0/js/bootstrap-datepicker.min.js" integrity="sha512-T/tUfKSV1bihCnd+MxKD0Hm1uBBroVYBOYSk1knyvQ9VyZJpc/ALb4P0r6ubwVPSGB2GvjeoMAJJImBG12TiaQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script src="https://maps.googleapis.com/maps/api/js?key=@(Model.GoogleMapsApiKey)&libraries=geometry"></script>
     <script src="~/static/js/main.js" asp-append-version="true"></script>
     <script>
         $('.calendar').datepicker({

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -131,7 +131,9 @@ static void RunApplication(string[] args)
     app.UseRouting();
     app.MapRazorPages();
 
-    app.MapGet("/api/tracks", async (
+    var api = app.MapGroup("/api/tracks");
+
+    api.MapGet(string.Empty, static async (
         TrackService service,
         DateTimeOffset? notBefore,
         DateTimeOffset? notAfter,
@@ -141,13 +143,13 @@ static void RunApplication(string[] args)
         return Results.Json(tracks, ApplicationJsonSerializerContext.Default.ListTrack);
     });
 
-    app.MapGet("/api/tracks/count", async (TrackService service, CancellationToken cancellationToken) =>
+    api.MapGet("/count", static async (TrackService service, CancellationToken cancellationToken) =>
     {
         int count = await service.GetTrackCountAsync(cancellationToken);
         return Results.Json(new TrackCount() { Count = count }, ApplicationJsonSerializerContext.Default.TrackCount);
     });
 
-    app.MapPost("/api/tracks/import", async (TrackImporter importer, CancellationToken cancellationToken) =>
+    api.MapPost("/import", static async (TrackImporter importer, CancellationToken cancellationToken) =>
     {
         int count = await importer.ImportTracksAsync(cancellationToken);
         return Results.Json(

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -66,7 +66,7 @@ static void RunApplication(string[] args)
         });
 
     builder.Services.Configure<Microsoft.AspNetCore.Http.Json.JsonOptions>(
-        (options) => options.SerializerOptions.TypeInfoResolverChain.Add(ApplicationJsonSerializerContext.Default));
+        (options) => options.SerializerOptions.TypeInfoResolverChain.Insert(0, ApplicationJsonSerializerContext.Default));
 
     builder.Services.Configure<StaticFileOptions>((options) =>
     {
@@ -131,19 +131,22 @@ static void RunApplication(string[] args)
         CancellationToken cancellationToken) =>
     {
         var tracks = await service.GetTracksAsync(notBefore, notAfter, cancellationToken);
-        return Results.Json(tracks);
+        return Results.Json(tracks, ApplicationJsonSerializerContext.Default.ListTrack);
     });
 
     app.MapGet("/api/tracks/count", async (TrackService service, CancellationToken cancellationToken) =>
     {
         int count = await service.GetTrackCountAsync(cancellationToken);
-        return Results.Json(new TrackCount() { Count = count });
+        return Results.Json(new TrackCount() { Count = count }, ApplicationJsonSerializerContext.Default.TrackCount);
     });
 
     app.MapPost("/api/tracks/import", async (TrackImporter importer, CancellationToken cancellationToken) =>
     {
         int count = await importer.ImportTracksAsync(cancellationToken);
-        return Results.Json(new TrackCount() { Count = count }, statusCode: StatusCodes.Status201Created);
+        return Results.Json(
+            new TrackCount() { Count = count },
+            ApplicationJsonSerializerContext.Default.TrackCount,
+            statusCode: StatusCodes.Status201Created);
     });
 
     app.Run();

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -107,19 +107,26 @@ static void RunApplication(string[] args)
 
     builder.Services.AddRazorPages();
 
-    builder.Services.Configure<BrotliCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
-    builder.Services.Configure<GzipCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
-
-    builder.Services.AddResponseCompression((p) =>
+    if (!builder.Environment.IsDevelopment())
     {
-        p.EnableForHttps = true;
-        p.Providers.Add<BrotliCompressionProvider>();
-        p.Providers.Add<GzipCompressionProvider>();
-    });
+        builder.Services.Configure<BrotliCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
+        builder.Services.Configure<GzipCompressionProviderOptions>((p) => p.Level = CompressionLevel.Fastest);
+
+        builder.Services.AddResponseCompression((p) =>
+        {
+            p.EnableForHttps = true;
+            p.Providers.Add<BrotliCompressionProvider>();
+            p.Providers.Add<GzipCompressionProvider>();
+        });
+    }
 
     var app = builder.Build();
 
-    app.UseResponseCompression();
+    if (!builder.Environment.IsDevelopment())
+    {
+        app.UseResponseCompression();
+    }
+
     app.UseStaticFiles();
     app.UseRouting();
     app.MapRazorPages();

--- a/src/AppleFitnessWorkoutMapper/Services/TrackImporter.cs
+++ b/src/AppleFitnessWorkoutMapper/Services/TrackImporter.cs
@@ -33,7 +33,7 @@ public sealed partial class TrackImporter(
 
         foreach (var track in tracks)
         {
-            var trackDB = new Data.Track()
+            var trackDB = new Track()
             {
                 Name = track.Name,
                 Timestamp = track.Timestamp.UtcDateTime,
@@ -41,11 +41,11 @@ public sealed partial class TrackImporter(
 
             trackDB = (await context.Tracks.AddAsync(trackDB, cancellationToken)).Entity;
 
-            var points = new List<Data.TrackPoint>(track.Points.Count);
+            var points = new List<TrackPoint>(track.Points.Count);
 
             foreach (var point in track.Points)
             {
-                var pointDB = new Data.TrackPoint()
+                var pointDB = new TrackPoint()
                 {
                     Latitude = point.Latitude,
                     Longitude = point.Longitude,

--- a/src/AppleFitnessWorkoutMapper/Services/TrackParser.cs
+++ b/src/AppleFitnessWorkoutMapper/Services/TrackParser.cs
@@ -36,9 +36,7 @@ public sealed partial class TrackParser(
             }
         }
 
-        var comparer = Comparer<DateTimeOffset>.Default;
-
-        result.Sort((x, y) => comparer.Compare(x.Timestamp, y.Timestamp));
+        result.Sort((x, y) => x.Timestamp.CompareTo(y.Timestamp));
 
         Log.ParsedTrackData(logger, result.Count, path);
 
@@ -67,7 +65,7 @@ public sealed partial class TrackParser(
         string fileName,
         CancellationToken cancellationToken)
     {
-        using Stream stream = File.OpenRead(fileName);
+        using var stream = File.OpenRead(fileName);
 
         XElement root;
 
@@ -129,7 +127,7 @@ public sealed partial class TrackParser(
             return null;
         }
 
-        result.Timestamp = result.Points.First().Timestamp;
+        result.Timestamp = result.Points[0].Timestamp;
 
         Log.AddedTrackPointsFromFile(
             logger,

--- a/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
+++ b/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
@@ -66,7 +66,5 @@ public class TrackService(TracksContext context)
     }
 
     private async Task EnsureDatabaseAsync(CancellationToken cancellationToken)
-    {
-        await context.Database.EnsureCreatedAsync(cancellationToken);
-    }
+        => await context.Database.EnsureCreatedAsync(cancellationToken);
 }

--- a/src/AppleFitnessWorkoutMapper/package-lock.json
+++ b/src/AppleFitnessWorkoutMapper/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@babel/core": "^7.23.3",
         "@babel/preset-env": "^7.23.3",
+        "@googlemaps/js-api-loader": "^1.16.2",
         "@types/google.maps": "^3.54.8",
         "@types/jquery": "^3.5.27",
         "@typescript-eslint/eslint-plugin": "^6.11.0",
@@ -1848,6 +1849,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@googlemaps/js-api-loader": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@googlemaps/js-api-loader/-/js-api-loader-1.16.2.tgz",
+      "integrity": "sha512-psGw5u0QM6humao48Hn4lrChOM2/rA43ZCm3tKK9qQsEj1/VzqkCqnvGfEOshDbBQflydfaRovbKwZMF4AyqbA==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/src/AppleFitnessWorkoutMapper/package.json
+++ b/src/AppleFitnessWorkoutMapper/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.3",
     "@babel/preset-env": "^7.23.3",
+    "@googlemaps/js-api-loader": "^1.16.2",
     "@types/google.maps": "^3.54.8",
     "@types/jquery": "^3.5.27",
     "@typescript-eslint/eslint-plugin": "^6.11.0",

--- a/src/AppleFitnessWorkoutMapper/scripts/ts/view/Tracker.ts
+++ b/src/AppleFitnessWorkoutMapper/scripts/ts/view/Tracker.ts
@@ -1,10 +1,11 @@
 // Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+import { Loader } from '@googlemaps/js-api-loader';
 import { ApiClient } from '../client/ApiClient';
-import { TrackerUI } from './TrackerUI';
 import { TrackMap } from './TrackMap';
 import { TrackPath } from './TrackPath';
+import { TrackerUI } from './TrackerUI';
 
 export class Tracker {
     private readonly ui: TrackerUI;
@@ -17,7 +18,7 @@ export class Tracker {
     }
 
     async initialize() {
-        this.map = new TrackMap(this.ui.map);
+        this.map = await this.createMap();
         this.client = new ApiClient();
 
         this.ui.filterButton.addEventListener('click', () => {
@@ -145,5 +146,16 @@ export class Tracker {
         this.ui.enableFilters();
 
         return tracks.length;
+    }
+
+    private async createMap(): Promise<TrackMap> {
+        const apiKey = this.ui.map.getAttribute('data-google-api-key');
+        const loader = new Loader({
+            apiKey: apiKey,
+            version: 'weekly',
+            libraries: ['geometry'],
+        });
+        await loader.importLibrary('maps');
+        return new TrackMap(this.ui.map);
     }
 }


### PR DESCRIPTION
- Simply sorting of tracks.
- Use indexer instead of First().
- Use some newer C# syntax.
- Remove redundant syntax.
- Explicitly use the JSON source generator for serialization.
- Fix BrowserLink warning by only enabling compression outside of local development.
- Use a group for the API endpoints.
- Make endpoint handler methods static.
- Fix browser console warnings by refactoring how the Google Maps API is loaded by using `@googlemaps/js-api-loader`.