### PR TITLE
Improve filtering

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml
@@ -1,14 +1,8 @@
 @page
-@using System.Globalization;
 @using MartinCostello.AppleFitnessWorkoutMapper;
 @using MartinCostello.AppleFitnessWorkoutMapper.Pages;
 @addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"
 @model IndexModel
-@{
-    var today = Model.TimeProvider.GetUtcNow().UtcDateTime.Date;
-    string startDate = today.AddDays(-28).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-    string endDate = today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -89,7 +83,7 @@
                                     <i class="bi-calendar-event" aria-hidden="true"></i>
                                 </span>
                             </div>
-                            <input type="text" autocomplete="off" class="form-control calendar" placeholder="Start date" value="@startDate" aria-label="Start date" id="not-before" disabled>
+                            <input type="text" autocomplete="off" class="form-control calendar" placeholder="Start date" value="@(Model.StartDate)" aria-label="Start date" id="not-before" disabled>
                         </div>
                         <div class="input-group mb-3">
                             <div class="input-group-prepend" aria-hidden="true">
@@ -97,7 +91,7 @@
                                     <i class="bi-calendar-event" aria-hidden="true"></i>
                                 </span>
                             </div>
-                            <input type="text" autocomplete="off" class="form-control calendar" placeholder="End date" value="@endDate" aria-label="End date" id="not-after" disabled>
+                            <input type="text" autocomplete="off" class="form-control calendar" placeholder="End date" value="@(Model.EndDate)" aria-label="End date" id="not-after" disabled>
                         </div>
                         <div class="input-group mb-3">
                             <div class="btn-toolbar" role="toolbar">

--- a/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
+++ b/src/AppleFitnessWorkoutMapper/Pages/Index.cshtml.cs
@@ -1,18 +1,38 @@
 ﻿// Copyright (c) Martin Costello, 2021. All rights reserved.
 // Licensed under the Apache 2.0 license. See the LICENSE file in the project root for full license information.
 
+using MartinCostello.AppleFitnessWorkoutMapper.Services;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.Extensions.Options;
 
 namespace MartinCostello.AppleFitnessWorkoutMapper.Pages;
 
-public class IndexModel(TimeProvider timeProvider, IOptions<ApplicationOptions> options) : PageModel
+public class IndexModel(
+    TrackService service,
+    TimeProvider timeProvider,
+    IOptions<ApplicationOptions> options) : PageModel
 {
-    public TimeProvider TimeProvider { get; } = timeProvider;
-
     public string GoogleMapsApiKey { get; } = options.Value.GoogleMapsApiKey;
 
-    public void OnGet()
+    public string? StartDate { get; private set; }
+
+    public string? EndDate { get; private set; }
+
+    public async Task OnGet(CancellationToken cancellationToken)
     {
+        var today = timeProvider.GetUtcNow().UtcDateTime.Date;
+        var timestamp = await service.GetLatestTrackAsync(cancellationToken);
+
+        timestamp ??= today;
+
+        var endDate = timestamp.GetValueOrDefault().Date;
+
+        if (endDate < today)
+        {
+            endDate = endDate.AddDays(1);
+        }
+
+        StartDate = endDate.AddDays(-28).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        EndDate = endDate.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
     }
 }

--- a/src/AppleFitnessWorkoutMapper/Program.cs
+++ b/src/AppleFitnessWorkoutMapper/Program.cs
@@ -100,6 +100,7 @@ static void RunApplication(string[] args)
 
     const string Key = "Database";
 
+    builder.Services.AddResilienceEnricher();
     builder.Services.AddResiliencePipeline(Key, (builder) =>
     {
         builder.AddRetry(new()

--- a/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
+++ b/src/AppleFitnessWorkoutMapper/Services/TrackService.cs
@@ -8,6 +8,12 @@ namespace MartinCostello.AppleFitnessWorkoutMapper.Services;
 
 public class TrackService(TracksContext context)
 {
+    public async Task<DateTime?> GetLatestTrackAsync(CancellationToken cancellationToken = default)
+    {
+        await EnsureDatabaseAsync(cancellationToken);
+        return await context.Tracks.MaxAsync((p) => (DateTime?)p.Timestamp, cancellationToken);
+    }
+
     public async Task<int> GetTrackCountAsync(CancellationToken cancellationToken = default)
     {
         await EnsureDatabaseAsync(cancellationToken);

--- a/src/AppleFitnessWorkoutMapper/appsettings.json
+++ b/src/AppleFitnessWorkoutMapper/appsettings.json
@@ -5,7 +5,8 @@
       "Microsoft": "Warning",
       "Microsoft.AspNetCore.DataProtection.KeyManagement.XmlKeyManager": "Error",
       "Microsoft.AspNetCore.DataProtection.Repositories.FileSystemXmlRepository": "Error",
-      "Microsoft.Hosting.Lifetime": "Information"
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Polly": "Warning"
     }
   },
   "AllowedHosts": "*",


### PR DESCRIPTION
- When the most recent track is more than 28 days old, no data is shown. Improve this by dynamically changing the default date range filter by querying for the most recent date.
- Only log warnings from Polly and restore resilience enrichment.
