### PR TITLE
Bump minimum version

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Info.plist
+++ b/src/AppleFitnessWorkoutMapper/Info.plist
@@ -23,7 +23,7 @@
 		<key>CFBundleVersion</key>
 		<string>1.3.2</string>
 		<key>LSMinimumSystemVersion</key>
-		<string>10.15</string>
+		<string>12.0</string>
 		<key>NSHumanReadableCopyright</key>
 		<string>Martin Costello (c) 2021</string>
 	</dict>


### PR DESCRIPTION
Require macOS 12 as a minimum version.
<!--

Summarise the changes this Pull Request makes.

Please include a reference to a GitHub issue if appropriate.

-->
