### PR TITLE
Fix CS8618 warnings

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
+++ b/src/AppleFitnessWorkoutMapper/Data/TracksContext.cs
@@ -7,7 +7,7 @@ namespace MartinCostello.AppleFitnessWorkoutMapper.Data;
 
 public sealed class TracksContext(DbContextOptions options) : DbContext(options)
 {
-    public DbSet<Track> Tracks { get; init; }
+    public DbSet<Track> Tracks { get; init; } = default!;
 
-    public DbSet<TrackPoint> TrackPoints { get; init; }
+    public DbSet<TrackPoint> TrackPoints { get; init; } = default!;
 }


### PR DESCRIPTION
Fix two CS8618 warnings surfaced by `dotnet format analyzers` as part of testing for martincostello/dotnet-bumper#152.
