### PR TITLE
Attest artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,8 @@ jobs:
         runner.os == 'Linux' &&
         github.event.repository.fork == false &&
         (github.ref_name == github.event.repository.default_branch ||
-         startsWith(github.ref, 'refs/tags/v'))
+         startsWith(github.ref, 'refs/tags/v') ||
+         inputs.notarize == true)
       env:
         GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
         GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
@@ -139,7 +140,8 @@ jobs:
         runner.os == 'Linux' &&
         github.event.repository.fork == false &&
         (github.ref_name == github.event.repository.default_branch ||
-         startsWith(github.ref, 'refs/tags/v'))
+         startsWith(github.ref, 'refs/tags/v') ||
+         inputs.notarize == true)
       with:
         subject-path: |
           ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.zip
@@ -202,8 +204,9 @@ jobs:
 
   notarize:
     if: |
-      (github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')) ||
-      inputs.notarize == 'true'
+      github.event.repository.fork == false &&
+      (startsWith(github.ref, 'refs/tags/v') ||
+       inputs.notarize == true)
     needs: [ build ]
     runs-on: macos-latest
 
@@ -360,10 +363,7 @@ jobs:
 
     - name: Create GitHub release
       uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        draft: true
         files: |
           *.zip
           *.zip.sig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
+
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +127,15 @@ jobs:
           gpg --verify "${fname}.sig" "${fname}"
         done
 
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      #if: |
+      #  runner.os == 'Linux' &&
+      #  github.event.repository.fork == false &&
+      #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      with:
+        subject-path: ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
+
     - name: Publish ZIP artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: runner.os == 'Linux'
@@ -173,7 +187,7 @@ jobs:
         if-no-files-found: ignore
 
   notarize:
-    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
+    #if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
     needs: [ build ]
     runs-on: macos-latest
 
@@ -181,6 +195,11 @@ jobs:
       MACOS_APP_NAME: AppleFitnessWorkoutMapper.app
       MACOS_APP_PATH: ./artifacts/AppleFitnessWorkoutMapper.app
       MACOS_ARTIFACTS_PATH: ./artifacts
+
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -218,7 +237,7 @@ jobs:
     - name: Configure Xcode
       uses: martincostello/xcode-select@db3d404e6e20374a638c10a68e3d804977ec19cb # node20
       with:
-        version: "15.3"
+        version: '15.3'
 
     - name: Import Distribution Certificate
       uses: martincostello/import-signing-certificate@a80a8cdd27ba2b00e0e80480fb66c4149de04061 # node20
@@ -282,6 +301,11 @@ jobs:
         gpg --batch --yes --pinentry-mode loopback --passphrase "${GPG_PASSPHRASE}" --detach-sig "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip"
         gpg --verify "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip.sig" "./artifacts/AppleFitnessWorkoutMapper-osx-${APP_PLATFORM}.zip"
 
+    - name: Attest artifacts
+      uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
+      with:
+        subject-path: ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
+
     - name: Publish notarized ZIP artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
@@ -291,6 +315,7 @@ jobs:
           ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip.sig
 
   release:
+    if: false
     needs: [ notarize ]
     runs-on: ubuntu-latest
 
@@ -306,10 +331,10 @@ jobs:
 
     - name: Create GitHub release
       uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         draft: true
         files: |
           *.zip
           *.zip.sig
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,9 +129,11 @@ jobs:
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
-      if: runner.os == 'Linux'
-        #github.event.repository.fork == false &&
-        #(github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      if: |
+        runner.os == 'Linux' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch ||
+         startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: |
           ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.zip
@@ -193,7 +195,7 @@ jobs:
         if-no-files-found: ignore
 
   notarize:
-    #if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
+    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
     needs: [ build ]
     runs-on: macos-latest
 
@@ -347,17 +349,12 @@ jobs:
         name: app-zips-notarized-x64
         path: .
 
-    - name: List files
-      shell: bash
-      run: |
-        ls -la .
-
-    #- name: Create GitHub release
-    #  uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
-    #  env:
-    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    #  with:
-    #    draft: true
-    #    files: |
-    #      *.zip
-    #      *.zip.sig
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        draft: true
+        files: |
+          *.zip
+          *.zip.sig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,10 +129,10 @@ jobs:
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
-      #if: |
-      #  runner.os == 'Linux' &&
-      #  github.event.repository.fork == false &&
-      #  (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      if: |
+        runner.os == 'Linux' &&
+        github.event.repository.fork == false &&
+        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
         subject-path: ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ on:
       - dotnet-vnext
       - dotnet-nightly
   workflow_dispatch:
+    inputs:
+      notarize:
+        type: boolean
+        default: false
+        description: 'Whether to notarize the macOS app.'
+        required: false
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -195,7 +201,9 @@ jobs:
         if-no-files-found: ignore
 
   notarize:
-    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')) ||
+      inputs.notarize == 'true'
     needs: [ build ]
     runs-on: macos-latest
 
@@ -323,6 +331,7 @@ jobs:
           ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip.sig
 
   release:
+    if: github.event.repository.fork == false && startsWith(github.ref, 'refs/tags/v')
     needs: [ notarize ]
     runs-on: ubuntu-latest
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,12 +129,14 @@ jobs:
 
     - name: Attest artifacts
       uses: actions/attest-build-provenance@951c0c5f8e375ad4efad33405ab77f7ded2358e4 # v1.1.1
-      if: |
-        runner.os == 'Linux' &&
-        github.event.repository.fork == false &&
-        (github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
+      if: runner.os == 'Linux'
+        #github.event.repository.fork == false &&
+        #(github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/v'))
       with:
-        subject-path: ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
+        subject-path: |
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-linux-*.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-win-*.zip
 
     - name: Publish ZIP artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
@@ -143,8 +145,12 @@ jobs:
         if-no-files-found: error
         name: app-zips
         path: |
-          ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip
-          ./artifacts/publish/AppleFitnessWorkoutMapper/*.zip.sig
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.zip.sig
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-linux-*.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-linux-*.zip.sig
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-win-*.zip
+          ./artifacts/publish/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper-win-*.zip.sig
 
     - name: Publish macOS arm64 artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
@@ -283,7 +289,7 @@ jobs:
     - name: Publish signed app
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: app-macos-signed
+        name: app-macos-signed-${{ matrix.platform }}
         path: ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
 
     - name: GPG sign signed app
@@ -309,13 +315,12 @@ jobs:
     - name: Publish notarized ZIP artifacts
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       with:
-        name: app-zips-notarized
+        name: app-zips-notarized-${{ matrix.platform }}
         path: |
           ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip
           ./artifacts/AppleFitnessWorkoutMapper-osx-${{ matrix.platform }}.zip.sig
 
   release:
-    if: false
     needs: [ notarize ]
     runs-on: ubuntu-latest
 
@@ -324,17 +329,35 @@ jobs:
 
     steps:
 
-    - name: Download artifacts
+    - name: Download Linux and Windows artifacts
       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
-        name: app-zips-notarized
+        name: app-zips
+        path: .
 
-    - name: Create GitHub release
-      uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Download macOS arm64 artifacts
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
       with:
-        draft: true
-        files: |
-          *.zip
-          *.zip.sig
+        name: app-zips-notarized-arm64
+        path: .
+
+    - name: Download macOS x64 artifacts
+      uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+      with:
+        name: app-zips-notarized-x64
+        path: .
+
+    - name: List files
+      shell: bash
+      run: |
+        ls -la .
+
+    #- name: Create GitHub release
+    #  uses: softprops/action-gh-release@69320dbe05506a9a39fc8ae11030b214ec2d1f87 # v2.0.5
+    #  env:
+    #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    #  with:
+    #    draft: true
+    #    files: |
+    #      *.zip
+    #      *.zip.sig


### PR DESCRIPTION
- Attest the binaries and packages from the build artifacts.
- Ignore any `binlog` files.
