### PR TITLE
Add job timeout

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   lighthouse:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
 


### PR DESCRIPTION
If Lighthouse hangs for some reason, terminate after 10 minutes not 6 hours.
