### PR TITLE
Tidy-up templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,18 +1,22 @@
+---
+title: ''
+---
+
 <!--
-
 The more information you can provide, the easier it will be to help resolve your problem.
-
 -->
 
-<!-- markdownlint-disable MD041 -->
 ### Expected behaviour
 
-_Explain what you expected to happen._
+<!-- Explain what you expected to happen. -->
 
 ### Actual behaviour
 
-_Explain what actually happened. If an exception occurred, please include a stack trace if available._
+<!--
+A clear and concise description of what actually happened.
+If an exception occurred, please include logs and/or a stack trace if available.
+-->
 
 ### Steps to reproduce
 
-_A concise and repeatable example of how to illustrate the issue, including any screenshots if relevant._
+<!-- A concise, repeatable, example of how to illustrate the issue, including any screenshots if relevant. -->


### PR DESCRIPTION
Tidy up the suppressions for markdownlint to make the templates render better in the GitHub UI.
