### PR TITLE
Bump Polly to 8.5.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />
     <PackageVersion Include="Microsoft.TypeScript.MSBuild" Version="5.8.1" />
+    <PackageVersion Include="Polly.Core" Version="8.5.2" />
     <PackageVersion Include="RazorSlices" Version="0.9.1" />
     <PackageVersion Include="ReportGenerator" Version="5.4.5" />
     <PackageVersion Include="Shouldly" Version="4.3.0" />

--- a/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
+++ b/src/AppleFitnessWorkoutMapper/AppleFitnessWorkoutMapper.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.Extensions.Resilience" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" PrivateAssets="all" />
+    <PackageReference Include="Polly.Core" />
     <PackageReference Include="RazorSlices" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Add explicit package reference to force use of the latest version of Polly, rather than transitively via Microsoft.Extensions.Resilience.
