### PR TITLE
Remove redundant scripts

### DIFF
--- a/src/AppleFitnessWorkoutMapper/Slices/App.cshtml
+++ b/src/AppleFitnessWorkoutMapper/Slices/App.cshtml
@@ -9,8 +9,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/css/bootstrap.min.css" integrity="sha512-jnSuA4Ss2PkkikSOLtYs8BlYIeeIK1h99ty4YfvRPAlzr377vr3CXDb7sb7eEEBYjDtcYj+AjBH3FLv5uSJuXg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap4-toggle/3.6.1/bootstrap4-toggle.min.css" integrity="sha512-EzrsULyNzUc4xnMaqTrB4EpGvudqpetxG/WNjCpG6ZyyAGxeB6OBF9o246+mwx3l/9Cn838iLIcrxpPHTiygAA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-datepicker/1.10.0/css/bootstrap-datepicker.min.css" integrity="sha512-34s5cpvaNG3BknEWSuOncX28vz97bRI59UnVtEEpFX536A7BtZSJHsDyFoCl8S7Dt2TPzcrCEoHBGeM4SUBDBw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css" integrity="sha512-Evv84Mr4kqVGRNSgIGL/F/aIDqQb7xQ2vcrdIwxfjThSH8CSR7PBEakCr51Ck+w+/U6swU2Im1vVX0SVk9ABhg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="@(Content("~/static/css/styles.css"))">
     <link rel="dns-prefetch" href="https://cdnjs.cloudflare.com">

--- a/tests/AppleFitnessWorkoutMapper.Tests/Pages/ApplicationPage.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/Pages/ApplicationPage.cs
@@ -81,6 +81,9 @@ public sealed class ApplicationPage(IPage page)
         return this;
     }
 
+    public async Task WaitForMapAsync()
+        => await page.WaitUntilVisibleAsync(Selectors.Map);
+
     public async Task WaitForTracksAsync()
         => await page.WaitUntilVisibleAsync(Selectors.TrackItem);
 

--- a/tests/AppleFitnessWorkoutMapper.Tests/UITests.cs
+++ b/tests/AppleFitnessWorkoutMapper.Tests/UITests.cs
@@ -63,6 +63,7 @@ public class UITests(ITestOutputHelper outputHelper) : IAsyncLifetime
 
             // Assert
             await app.WaitForTracksAsync();
+            await app.WaitForMapAsync();
 
             await app.IsMapDisplayedAsync().ShouldBeTrue();
 


### PR DESCRIPTION
- Remove JavaScript imports that are no longer used since the upgrade to Bootstrap 5.
- Wait for the map to load to try and resolve flaky test.
